### PR TITLE
Add PostgreSQL database setup for GPU prices data

### DIFF
--- a/README_DB_SETUP.md
+++ b/README_DB_SETUP.md
@@ -1,0 +1,105 @@
+# GPU Prices Database Setup
+
+This document explains how to set up and use the PostgreSQL database for storing GPU price data.
+
+## Prerequisites
+
+- Docker and Docker Compose
+- Python 3.6+
+- psycopg2 Python package
+
+## Installation
+
+Install the required Python package:
+
+```bash
+pip install psycopg2-binary
+```
+
+## Starting the Database
+
+To start the PostgreSQL database using Docker Compose:
+
+```bash
+docker-compose up -d
+```
+
+This will start a PostgreSQL instance with the following configuration:
+- Host: localhost
+- Port: 5432
+- Database: gpu_prices
+- Username: postgres
+- Password: postgres
+
+## Setting Up the Database
+
+To create the necessary tables:
+
+```bash
+python setup_db.py
+```
+
+To create tables and populate with mock data:
+
+```bash
+python setup_db.py --with-mock-data
+```
+
+## Configuration
+
+The database connection is configurable through environment variables:
+
+### Development (Docker Compose)
+
+No configuration needed - defaults will connect to the local Docker container.
+
+### Custom Configuration
+
+You can customize individual connection parameters:
+
+```bash
+export DB_HOST=custom-host
+export DB_PORT=5432
+export DB_NAME=custom-db-name
+export DB_USER=custom-user
+export DB_PASSWORD=custom-password
+python setup_db.py
+```
+
+### Production
+
+For production, set the `POSTGRES_URL` environment variable:
+
+```bash
+export POSTGRES_URL=postgresql://user:password@hostname:port/database
+python setup_db.py
+```
+
+## Using in Your Application
+
+Import the configuration module to get connection details:
+
+```python
+from db_config import get_connection_string
+
+# Get connection string based on environment
+conn_string = get_connection_string()
+
+# Use with psycopg2
+import psycopg2
+conn = psycopg2.connect(conn_string)
+```
+
+## Database Schema
+
+The database contains the following table:
+
+### gpu_prices
+
+| Column      | Type           | Description                    |
+|-------------|----------------|--------------------------------|
+| id          | SERIAL         | Primary key                    |
+| gpu_model   | VARCHAR(100)   | GPU model name                 |
+| vram_gb     | VARCHAR(10)    | VRAM size in GB                |
+| price_usd   | NUMERIC(10, 2) | Price in USD (can be NULL)     |
+| created_at  | TIMESTAMP      | Record creation timestamp      |

--- a/db_config.py
+++ b/db_config.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+import os
+
+def get_db_config():
+    """
+    Returns database configuration based on environment
+    
+    In development: Uses local Docker Compose PostgreSQL instance
+    In production: Uses the PostgreSQL URL from environment variables
+    """
+    # Default development configuration (matches docker-compose.yml)
+    config = {
+        'host': os.environ.get('DB_HOST', 'localhost'),
+        'port': os.environ.get('DB_PORT', '5432'),
+        'database': os.environ.get('DB_NAME', 'gpu_prices'),
+        'user': os.environ.get('DB_USER', 'postgres'),
+        'password': os.environ.get('DB_PASSWORD', 'postgres')
+    }
+    
+    # If POSTGRES_URL is set, it overrides individual settings (used in production)
+    postgres_url = os.environ.get('POSTGRES_URL')
+    if postgres_url:
+        return {'url': postgres_url}
+    
+    return config
+
+def get_connection_string():
+    """
+    Returns a connection string for PostgreSQL based on configuration
+    """
+    config = get_db_config()
+    
+    # If URL is directly provided, return it
+    if 'url' in config:
+        return config['url']
+    
+    # Otherwise, build connection string from individual parameters
+    return f"postgresql://{config['user']}:{config['password']}@{config['host']}:{config['port']}/{config['database']}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:15
+    container_name: gpu_prices_db
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: gpu_prices
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    restart: unless-stopped
+
+volumes:
+  postgres_data:

--- a/query_gpu_prices.py
+++ b/query_gpu_prices.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+import psycopg2
+import logging
+from db_config import get_connection_string
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+def query_all_prices():
+    """Query and display all GPU prices from the database"""
+    conn_string = get_connection_string()
+    
+    try:
+        # Connect to the database
+        conn = psycopg2.connect(conn_string)
+        
+        # Create a cursor
+        with conn.cursor() as cur:
+            # Execute the query
+            cur.execute("""
+                SELECT gpu_model, vram_gb, price_usd, created_at
+                FROM gpu_prices
+                ORDER BY gpu_model, vram_gb
+            """)
+            
+            # Fetch all results
+            rows = cur.fetchall()
+            
+            # Print the results
+            print("\n===== GPU Prices =====")
+            print(f"{'GPU Model':<25} {'VRAM (GB)':<10} {'Price (USD)':<12} {'Created At'}")
+            print("-" * 70)
+            
+            for row in rows:
+                model, vram, price, created_at = row
+                price_str = f"${price:.2f}" if price is not None else "N/A"
+                print(f"{model:<25} {vram:<10} {price_str:<12} {created_at}")
+                
+            print(f"\nTotal records: {len(rows)}")
+            
+        # Close the connection
+        conn.close()
+        
+    except Exception as e:
+        logger.error(f"Error querying database: {e}")
+
+if __name__ == "__main__":
+    query_all_prices()

--- a/setup_db.py
+++ b/setup_db.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+import os
+import sys
+import psycopg2
+from psycopg2 import sql
+import logging
+from mock.serverless_gpu import prices
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+def get_db_url():
+    """
+    Get the PostgreSQL connection URL from environment variable or use default for development
+    """
+    return os.environ.get(
+        'POSTGRES_URL', 
+        'postgresql://postgres:postgres@localhost:5432/gpu_prices'
+    )
+
+def create_tables(conn):
+    """Create the necessary tables in the database"""
+    with conn.cursor() as cur:
+        cur.execute("""
+        CREATE TABLE IF NOT EXISTS gpu_prices (
+            id SERIAL PRIMARY KEY,
+            gpu_model VARCHAR(100) NOT NULL,
+            vram_gb VARCHAR(10) NOT NULL,
+            price_usd NUMERIC(10, 2),
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        """)
+        conn.commit()
+        logger.info("Tables created successfully")
+
+def insert_mock_data(conn):
+    """Insert mock data into the database"""
+    with conn.cursor() as cur:
+        for item in prices:
+            # Handle NaN values in price
+            price = item['price($)']
+            if price == 'NaN':
+                price = None
+                
+            cur.execute(
+                """
+                INSERT INTO gpu_prices (gpu_model, vram_gb, price_usd)
+                VALUES (%s, %s, %s)
+                """,
+                (
+                    item['gpu_model'],
+                    item['vram(GB)'],
+                    price
+                )
+            )
+        conn.commit()
+        logger.info(f"Inserted {len(prices)} records into gpu_prices table")
+
+def main():
+    """Main function to set up the database"""
+    db_url = get_db_url()
+    logger.info(f"Connecting to database: {db_url}")
+    
+    try:
+        conn = psycopg2.connect(db_url)
+        create_tables(conn)
+        
+        # Check if we should insert mock data
+        if len(sys.argv) > 1 and sys.argv[1] == '--with-mock-data':
+            insert_mock_data(conn)
+            
+        conn.close()
+        logger.info("Database setup completed successfully")
+        
+    except Exception as e:
+        logger.error(f"Error setting up database: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/setup_gpu_db.sh
+++ b/setup_gpu_db.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Script to set up the GPU prices database
+
+# Start the PostgreSQL container
+echo "Starting PostgreSQL container..."
+docker-compose up -d
+
+# Wait for PostgreSQL to be ready
+echo "Waiting for PostgreSQL to be ready..."
+sleep 5
+
+# Install required Python package if not already installed
+pip install psycopg2-binary
+
+# Set up the database tables
+echo "Setting up database tables..."
+python setup_db.py --with-mock-data
+
+echo "Database setup complete!"
+echo "You can now query the database using: python query_gpu_prices.py"


### PR DESCRIPTION
## Description
This PR adds PostgreSQL database setup for storing GPU prices data.

## Changes
- Added `docker-compose.yml` to provision a PostgreSQL container
- Created `setup_db.py` script to set up database tables
- Added `db_config.py` for configurable database connection settings
- Created `query_gpu_prices.py` to demonstrate database queries
- Added `setup_gpu_db.sh` shell script for easy database setup
- Added comprehensive documentation in `README_DB_SETUP.md`

## Features
- PostgreSQL database configuration is environment-variable based
- Development environment uses Docker Compose
- Production environment can use any PostgreSQL URL
- Includes scripts to populate the database with mock GPU price data

## Testing
To test this implementation:
1. Run `./setup_gpu_db.sh` to start the database and set up tables
2. Run `python query_gpu_prices.py` to verify data was inserted correctly